### PR TITLE
Tablas, variables y acentos

### DIFF
--- a/comparators/comparators.c
+++ b/comparators/comparators.c
@@ -3,6 +3,7 @@ int compararPorFechayClasificador(const void *a, const void *b)
 {
     const Fila *filaA = a;
     const Fila *filaB = b;
+    char clasifA, clasifB;
 
     int cmp = FechaComparar(&filaA->periodo, &filaB->periodo);
     if (cmp != 0)
@@ -10,8 +11,8 @@ int compararPorFechayClasificador(const void *a, const void *b)
         return cmp;
     }
 
-    char clasifA = *filaA->clasificador;
-    char clasifB = *filaB->clasificador;
+    clasifA = *filaA->clasificador;
+    clasifB = *filaB->clasificador;
 
     if (clasifA != clasifB)
     {
@@ -33,23 +34,26 @@ int compararPorFechayClasificador(const void *a, const void *b)
 
 int compararRegistros(const void *a, const void *b)
 {
+    Fecha fechaA, fechaB;
+    char clasiA, clasifB;
+    const char *tipoA, *tipoB;
+    int cmp;
+
     const RegistroICC *regA = a;
     const RegistroICC *regB = b;
-
-    Fecha fechaA, fechaB;
 
     fechaDeCadena(&fechaA, regA->periodo);
     fechaDeCadena(&fechaB, regB->periodo);
 
     // Comparar por periodo
-    int cmp = FechaComparar(&fechaA, &fechaB);
+    cmp = FechaComparar(&fechaA, &fechaB);
     if (cmp)
         return cmp;
 
     // Si son iguales, comparar por clasificador
 
-    char clasifA = *regA->clasificador;
-    char clasifB = *regB->clasificador;
+    clasifA = *regA->clasificador;
+    clasifB = *regB->clasificador;
 
     // Si difiere en clasificacion, retornar aca
     if (clasifA != clasifB)
@@ -70,8 +74,8 @@ int compararRegistros(const void *a, const void *b)
     // IS la clasificacion es igual, comparar por tipo_variable
     // Ordenar por tipo_var
 
-    const char *tipoA = regA->tipoVariable;
-    const char *tipoB = regB->tipoVariable;
+    tipoA = regA->tipoVariable;
+    tipoB = regB->tipoVariable;
 
     if (strcmp(tipoA, tipoB) == 0) // Son iguales
         return 0;

--- a/comparators/comparators.c
+++ b/comparators/comparators.c
@@ -18,7 +18,7 @@ int compararPorFechayClasificador(const void *a, const void *b)
     {
         if (clasifA == 'N') // Nivel general
             return -1;
-        else if (clasifA == 'I') // Items
+        else if (clasifA == 'Í') // Items
             return 1;
 
         // clasifA == Capitulos
@@ -35,7 +35,7 @@ int compararPorFechayClasificador(const void *a, const void *b)
 int compararRegistros(const void *a, const void *b)
 {
     Fecha fechaA, fechaB;
-    char clasiA, clasifB;
+    char clasifA, clasifB;
     const char *tipoA, *tipoB;
     int cmp;
 
@@ -60,7 +60,7 @@ int compararRegistros(const void *a, const void *b)
     {
         if (clasifA == 'N') // A = Nivel general -> B es menor
             return -1;
-        else if (clasifA == 'I') // A = Items -> B es mayor
+        else if (clasifA == 'Í') // A = Items -> B es mayor
             return 1;
 
         // clasifA == Capitulos (el del medio)

--- a/io/io.c
+++ b/io/io.c
@@ -12,7 +12,7 @@ void mostrarVector(Vector *registros)
 void mostrarVectorFinal(Vector *regs)
 {
     printf("== Mostrar vector Final ==\n\n");
-    printf("%-12s | %-16s | %-14s | %-60s | %-16s\n", "Periodo", "Clasificador", "Tipo_variable", "Nivel General Aperuras", "Valor");
+    printf("%-12s | %-16s | %-60s | %-14s | %-16s\n", "Periodo", "Clasificador", "Nivel General Aperuras", "Tipo_variable", "Valor");
     printf("------------------------------------------------------------------------------------------------------------------------------------------------------\n");
 
     vectorRecorrer(regs, mostrarRegistroVectorFinal, regs);
@@ -21,19 +21,19 @@ void mostrarRegistroVectorFinal(void *elem, void *datos)
 {
     RegistroICC *registro = elem;
 
-    printf("%-12s | %-16s | %-14s | %-60s | %-16f\n",
+    printf("%-12s | %-16s | %-60s | %-14s | %-16f\n",
            registro->periodo,
            registro->clasificador,
-           registro->tipoVariable,
            registro->nivelGeneralAperturas,
+           registro->tipoVariable,
            registro->valor);
 }
 
 void mostrarRegistroVector(void *elem, void *datos)
 {
     Fila *registro = elem;
-
     char periodo[11];
+
     FechaConvertirAGuiones(periodo, &registro->periodo);
 
     printf("%-12s | %-60s | %-16f | %-15s | %-16f | %-16f\n",

--- a/io/io.c
+++ b/io/io.c
@@ -12,7 +12,7 @@ void mostrarVectorInicial(Vector *registros, const char *titulo)
 void mostrarVectorFinal(Vector *regs, const char *titulo)
 {
     printf("\n== %s ==\n\n", titulo);
-    printf("%-10s | %-14s | %-50s | %-14s | %-16s\n", "Periodo", "Clasificador", "Nivel General Aperuras", "Tipo_variable", "Valor");
+    printf("%-10s | %-14s | %-50s | %-10s | %-16s\n", "Periodo", "Clasificador", "Nivel General Aperuras", "Tipo_variable", "Valor");
     printf("----------------------------------------------------------------------------------------------------------------\n");
 
     vectorRecorrer(regs, mostrarRegistroVecFinal, regs);
@@ -38,7 +38,7 @@ void mostrarRegistroVecFinal(void *elem, void *datos)
 {
     RegistroICC *registro = elem;
 
-    printf("%-10s | %-14s | %-50s | %-14s | %-16f\n",
+    printf("%-10s | %-14s | %-50s | %-14s | %-10s\n",
            registro->periodo,
            registro->clasificador,
            registro->nivelGeneralAperturas,

--- a/io/io.c
+++ b/io/io.c
@@ -1,46 +1,47 @@
 #include "io.h"
 
-void mostrarVector(Vector *registros)
+void mostrarVectorInicial(Vector *registros, const char *titulo)
 {
-    printf("== Mostrar vector ==\n\n");
-    printf("%-12s | %-60s | %-16s | %-15s | %-16s | %-16s\n", "Periodo", "Nivel", "Indice", "Clasificador", "var_mensual", "var_interanual");
-    printf("------------------------------------------------------------------------------------------------------------------------------------------------------\n");
+    printf("\n== %s ==\n\n", titulo);
+    printf("%-10s | %-42s | %-12s | %-14s | %-12s | %-14s\n", "Periodo", "Nivel", "Indice", "Clasificador", "var_mensual", "var_interanual");
+    printf("------------------------------------------------------------------------------------------------------------------------\n");
 
-    vectorRecorrer(registros, mostrarRegistroVector, registros);
+    vectorRecorrer(registros, mostrarRegistroVecInicial, registros);
 }
 
-void mostrarVectorFinal(Vector *regs)
+void mostrarVectorFinal(Vector *regs, const char *titulo)
 {
-    printf("== Mostrar vector Final ==\n\n");
-    printf("%-12s | %-16s | %-60s | %-14s | %-16s\n", "Periodo", "Clasificador", "Nivel General Aperuras", "Tipo_variable", "Valor");
-    printf("------------------------------------------------------------------------------------------------------------------------------------------------------\n");
+    printf("\n== %s ==\n\n", titulo);
+    printf("%-10s | %-14s | %-50s | %-14s | %-16s\n", "Periodo", "Clasificador", "Nivel General Aperuras", "Tipo_variable", "Valor");
+    printf("----------------------------------------------------------------------------------------------------------------\n");
 
-    vectorRecorrer(regs, mostrarRegistroVectorFinal, regs);
-}
-void mostrarRegistroVectorFinal(void *elem, void *datos)
-{
-    RegistroICC *registro = elem;
-
-    printf("%-12s | %-16s | %-60s | %-14s | %-16f\n",
-           registro->periodo,
-           registro->clasificador,
-           registro->nivelGeneralAperturas,
-           registro->tipoVariable,
-           registro->valor);
+    vectorRecorrer(regs, mostrarRegistroVecFinal, regs);
 }
 
-void mostrarRegistroVector(void *elem, void *datos)
+void mostrarRegistroVecInicial(void *elem, void *datos)
 {
     Fila *registro = elem;
     char periodo[11];
 
     FechaConvertirAGuiones(periodo, &registro->periodo);
 
-    printf("%-12s | %-60s | %-16f | %-15s | %-16f | %-16f\n",
+    printf("%-10s | %-42s | %-12f | %-14s | %-12f | %-14f\n",
            periodo,
            registro->nivelGeneralAperturas,
            registro->indiceICC,
            registro->clasificador,
            registro->varMensual,
            registro->varInteranual);
+}
+
+void mostrarRegistroVecFinal(void *elem, void *datos)
+{
+    RegistroICC *registro = elem;
+
+    printf("%-10s | %-14s | %-50s | %-14s | %-16f\n",
+           registro->periodo,
+           registro->clasificador,
+           registro->nivelGeneralAperturas,
+           registro->tipoVariable,
+           registro->valor);
 }

--- a/io/io.h
+++ b/io/io.h
@@ -5,9 +5,9 @@
 #include "../TDAFecha/TDAFecha.h"
 #include "../structs/fila.h"
 #include "../structs/registroICC.h"
-void mostrarVector(Vector *registros);
-void mostrarVectorFinal(Vector *regs);
-void mostrarRegistroVector(void *elem, void *datos);
-void mostrarRegistroVectorFinal(void *elem, void *datos);
+void mostrarVectorInicial(Vector *registros, const char *titulo);
+void mostrarVectorFinal(Vector *regs, const char *titulo);
+void mostrarRegistroVecInicial(void *elem, void *datos);
+void mostrarRegistroVecFinal(void *elem, void *datos);
 
 #endif // IO_H_INCLUDED

--- a/main.c
+++ b/main.c
@@ -4,11 +4,18 @@
 
 int main(int argc, char *argv[])
 {
-    Vector registros;
+    Vector registros, vEstrFinal;
+    FILE *archCapitulos, *archItems;
+    Fila fila;
+
+    char *periodo, *nivel, *indiceStr;
+    char registroData[256];
+    double valorNum;
+
     vectorCrear(&registros, sizeof(Fila));
 
-    FILE *archCapitulos = fopen(argv[1], "r");
-    FILE *archItems = fopen(argv[2], "r");
+    archCapitulos = fopen(argv[ARG_ARCH_CAPITULOS], "r");
+    archItems = fopen(argv[ARG_ARCH_ITEMS], "r");
 
     if (!archCapitulos || !archItems)
     {
@@ -16,18 +23,15 @@ int main(int argc, char *argv[])
         return ERR_ARCHIVO;
     }
 
-    char registroData[256];
 
     //////////////////// Archivo 1///////////////////////////////////////////
 
     fgets(registroData, sizeof(registroData), archCapitulos); // Salto la cabecera
     while (fgets(registroData, sizeof(registroData), archCapitulos))
     {
-        char *periodo = strtok(registroData, ";\"");
-        char *nivel = strtok(NULL, ";\"");
-        char *indiceStr = strtok(NULL, ";\"\n");
-
-        Fila fila;
+        periodo = strtok(registroData, ";\"");
+        nivel = strtok(NULL, ";\"");
+        indiceStr = strtok(NULL, ";\"\n");
 
         // Campo fecha
         Fecha nuevaFecha;
@@ -44,7 +48,7 @@ int main(int argc, char *argv[])
 
         // Campo indice
         reemplazarComaPorPunto(indiceStr);
-        double valorNum = strtod(indiceStr, NULL);
+        valorNum = strtod(indiceStr, NULL);
 
         // Se copia a la estructura de Registros
         strcpy(fila.nivelGeneralAperturas, nivel);
@@ -58,11 +62,9 @@ int main(int argc, char *argv[])
     fgets(registroData, sizeof(registroData), archItems); // Salto la cabecera
     while (fgets(registroData, sizeof(registroData), archItems))
     {
-        char *periodo = strtok(registroData, ";\"");
-        char *nivel = strtok(NULL, ";\"");
-        char *indiceStr = strtok(NULL, ";\"\n");
-
-        Fila fila;
+        periodo = strtok(registroData, ";\"");
+        nivel = strtok(NULL, ";\"");
+        indiceStr = strtok(NULL, ";\"\n");
 
         // Campo fecha
         Fecha nuevaFecha;
@@ -80,7 +82,7 @@ int main(int argc, char *argv[])
 
         // Campo indice
         reemplazarComaPorPunto(indiceStr);
-        double valorNum = strtod(indiceStr, NULL);
+        valorNum = strtod(indiceStr, NULL);
 
         // Se copia a la estructura de Registros
         strcpy(fila.nivelGeneralAperturas, nivel);
@@ -101,15 +103,23 @@ int main(int argc, char *argv[])
 
     mostrarVector(&registros);
 
-    Vector vEstrFinal;
+    // Final - Reorganizar, reordenar
     vectorCrear(&vEstrFinal, sizeof(RegistroICC));
 
     vectorRecorrer(&registros, cargarEstructuraRegistroIcc, &vEstrFinal);
+    vectorDestruir(&registros);
+
     vectorOrdenar(&vEstrFinal, QSORT, compararRegistros);
 
     mostrarVectorFinal(&vEstrFinal);
 
-    vectorGrabar(&vEstrFinal, argv[3]);
+    // Final - Guardar
+    vectorGrabar(&vEstrFinal, argv[ARG_ARCH_BIN]);
+    vectorDestruir(&vEstrFinal);
+
+    // Releer
+    vectorCrearDeArchivo(&vEstrFinal, sizeof(RegistroICC), argv[ARG_ARCH_BIN]);
+    mostrarVectorFinal(&vEstrFinal);
 
     return TODO_OK;
 }

--- a/main.c
+++ b/main.c
@@ -12,6 +12,8 @@ int main(int argc, char *argv[])
     char registroData[256];
     double valorNum;
 
+    system("chcp 1252 > nul");
+
     vectorCrear(&registros, sizeof(Fila));
 
     archCapitulos = fopen(argv[ARG_ARCH_CAPITULOS], "r");
@@ -101,7 +103,7 @@ int main(int argc, char *argv[])
     vectorRecorrer(&registros, calcularVarMensual, &registros);
     vectorRecorrer(&registros, calcularVarInteranual, &registros);
 
-    mostrarVector(&registros);
+    //mostrarVectorInicial(&registros, "Vector inicial ordenado (hasta p. 10)");
 
     // Final - Reorganizar, reordenar
     vectorCrear(&vEstrFinal, sizeof(RegistroICC));
@@ -111,7 +113,7 @@ int main(int argc, char *argv[])
 
     vectorOrdenar(&vEstrFinal, QSORT, compararRegistros);
 
-    mostrarVectorFinal(&vEstrFinal);
+    //mostrarVectorFinal(&vEstrFinal, "Vector final exportado");
 
     // Final - Guardar
     vectorGrabar(&vEstrFinal, argv[ARG_ARCH_BIN]);
@@ -119,7 +121,7 @@ int main(int argc, char *argv[])
 
     // Releer
     vectorCrearDeArchivo(&vEstrFinal, sizeof(RegistroICC), argv[ARG_ARCH_BIN]);
-    mostrarVectorFinal(&vEstrFinal);
+    mostrarVectorFinal(&vEstrFinal, "Vector leído de binario");
 
     return TODO_OK;
 }

--- a/main.h
+++ b/main.h
@@ -10,6 +10,8 @@
 #include "structs/fila.h"
 #include "structs/registroICC.h"
 
-
+#define ARG_ARCH_CAPITULOS 1
+#define ARG_ARCH_ITEMS 2
+#define ARG_ARCH_BIN 3
 
 #endif // MAIN_H_INCLUDED

--- a/procesamientoDeArchivo/procesamientoDeArchivo.c
+++ b/procesamientoDeArchivo/procesamientoDeArchivo.c
@@ -2,16 +2,16 @@
 
 void decodificar(char *cadena)
 {
+    int pos = 0, desp;
+    char c, base;
 
-    int pos = 0;
     while (*cadena != 0)
     {
-        char c = *cadena;
-        char base;
+        c = *cadena;
         if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'))
         {
             base = (c >= 'a') ? 'a' : 'A';
-            int desp = (pos % 2 == 0) ? 4 : 2;
+            desp = (pos % 2 == 0) ? 4 : 2;
 
             *cadena = base + ((c - base + desp) % 26);
         }

--- a/procesamientoDeArchivo/procesamientoDeArchivo.c
+++ b/procesamientoDeArchivo/procesamientoDeArchivo.c
@@ -24,11 +24,11 @@ void clasificador(Fila *reg, char *campo)
     if (strcmp(campo, "Nivel general") == 0)
         strcpy(reg->clasificador, "Nivel general");
     else
-        strcpy(reg->clasificador, "Capitulos");
+        strcpy(reg->clasificador, "Capítulos");
 }
 void clasificadorEnItem(Fila *reg)
 {
-    strcpy(reg->clasificador, "Items");
+    strcpy(reg->clasificador, "Ítems");
 }
 void desencriptarArchItems(char *campo)
 {

--- a/procesamientoDeArchivo/procesamientoDeArchivo.c
+++ b/procesamientoDeArchivo/procesamientoDeArchivo.c
@@ -77,25 +77,34 @@ void cargarEstructuraRegistroIcc(void *vec, void *elem)
     Fila *v = (Fila *)vec;
     RegistroICC reg;
 
+    // Pasar fecha, clasificador y nivel general aperturas
     FechaConvertirAGuiones(reg.periodo, &v->periodo);
     strcpy(reg.clasificador, v->clasificador);
     strcpy(reg.nivelGeneralAperturas, v->nivelGeneralAperturas);
 
+    // Pasar indice_icc como string
     strcpy(reg.tipoVariable, "indice_icc");
-    reg.valor = v->indiceICC;
+    sprintf(reg.valor, "%-10f", v->indiceICC);
+    *(reg.valor + 10) = '\0';
     vectorInsertarAlFinal(vFinal, &reg);
 
-    if (v->varMensual > -101)
-    {
-        strcpy(reg.tipoVariable, "var_mensual");
-        reg.valor = v->varMensual;
-        vectorInsertarAlFinal(vFinal, &reg);
-    }
+    strcpy(reg.tipoVariable, "var_mensual");
 
+    // Pasar var_mensual según si es NA o no
+    if (v->varMensual > -101)
+        sprintf(reg.valor, "%-.2f", v->varMensual);
+    else
+        strcpy(reg.valor, "NA");
+
+    vectorInsertarAlFinal(vFinal, &reg);
+
+    strcpy(reg.tipoVariable, "var_interanual");
+
+    // Pasar var_interanual según si es NA o no
     if (v->varInteranual > -101)
-    {
-        strcpy(reg.tipoVariable, "var_interanual");
-        reg.valor = v->varInteranual;
-        vectorInsertarAlFinal(vFinal, &reg);
-    }
+        sprintf(reg.valor, "%-.2f", v->varInteranual);
+    else
+        strcpy(reg.valor, "NA");
+
+    vectorInsertarAlFinal(vFinal, &reg);
 }

--- a/structs/registroICC.h
+++ b/structs/registroICC.h
@@ -8,7 +8,7 @@ typedef struct
     char clasificador[20]; // "Nivel general", "Capitulos", "Items"
     char nivelGeneralAperturas[40];
     char tipoVariable[15]; // "indice_icc", "var_mensual", "var_interanual"
-    double valor;
+    char valor[11];
 } RegistroICC;
 
 #endif // REGISTROICC_H_INCLUDED

--- a/tpTopicos.cbp
+++ b/tpTopicos.cbp
@@ -36,32 +36,32 @@
 		<Compiler>
 			<Add option="-Wall" />
 		</Compiler>
-		<Unit filename="comparators.c">
+		<Unit filename="comparators/comparators.c">
 			<Option compilerVar="CC" />
 		</Unit>
-		<Unit filename="comparators.h" />
-		<Unit filename="fila.h" />
-		<Unit filename="io.c">
+		<Unit filename="comparators/comparators.h" />
+		<Unit filename="io/io.c">
 			<Option compilerVar="CC" />
 		</Unit>
-		<Unit filename="io.h" />
+		<Unit filename="io/io.h" />
 		<Unit filename="main.c">
 			<Option compilerVar="CC" />
 		</Unit>
 		<Unit filename="main.h" />
-		<Unit filename="procesamientoDeArchivo.c">
+		<Unit filename="procesamientoDeArchivo/procesamientoDeArchivo.c">
 			<Option compilerVar="CC" />
 		</Unit>
-		<Unit filename="procesamientoDeArchivo.h" />
-		<Unit filename="registroICC.h" />
-		<Unit filename="utils.c">
+		<Unit filename="procesamientoDeArchivo/procesamientoDeArchivo.h" />
+		<Unit filename="structs/fila.h" />
+		<Unit filename="structs/registroICC.h" />
+		<Unit filename="utils/utils.c">
 			<Option compilerVar="CC" />
 		</Unit>
-		<Unit filename="utils.h" />
-		<Unit filename="variaciones.c">
+		<Unit filename="utils/utils.h" />
+		<Unit filename="variaciones/variaciones.c">
 			<Option compilerVar="CC" />
 		</Unit>
-		<Unit filename="variaciones.h" />
+		<Unit filename="variaciones/variaciones.h" />
 		<Extensions>
 			<lib_finder disable_auto="1" />
 		</Extensions>


### PR DESCRIPTION
Cambios:
- Te muestra ahora sólo la tabla de los campos luego de leer del binario (las otras están comentadas).
- Ajusté las tablas así entran en el ancho por defecto de la consola.
- Moví todas las variables al inicio por las dudas.
- Me dí cuenta que había que poner en clasificador "Capítulos" e "Ítems", con acento y todo. Todos los ejemplos del pdf y la muestra lo tienen. Así que lo puse y ajusté el encoding de la consola para que encaje.